### PR TITLE
feat: implement claim cooldown mechanism with 24-hour restriction

### DIFF
--- a/apps/server/prisma/migrations/20260122145709_add_lastClaim_to_staked_pool/migration.sql
+++ b/apps/server/prisma/migrations/20260122145709_add_lastClaim_to_staked_pool/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `staked_pools` ADD COLUMN `lastClaim` DATETIME NULL;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -245,6 +245,7 @@ model StakedPool {
   userWalletId Int
   poolId       Int
   stakeAmount  String    @db.Text // Using Text to handle potentially very large stake amounts
+  lastClaim    DateTime? // Timestamp of the last reward claim
   createdAt    DateTime  @default(now())
   updatedAt    DateTime? @updatedAt
 
@@ -252,6 +253,7 @@ model StakedPool {
   pool       CreatorPool @relation(fields: [poolId], references: [id], onDelete: Cascade)
 
   @@unique([userWalletId, poolId]) // Each wallet can only have one staking entry per pool
+  @@index([userWalletId, poolId, lastClaim]) // Index for cooldown queries
   @@map("staked_pools")
 }
 

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -253,7 +253,6 @@ model StakedPool {
   pool       CreatorPool @relation(fields: [poolId], references: [id], onDelete: Cascade)
 
   @@unique([userWalletId, poolId]) // Each wallet can only have one staking entry per pool
-  @@index([userWalletId, poolId, lastClaim]) // Index for cooldown queries
   @@map("staked_pools")
 }
 

--- a/apps/server/src/trpc/pools/creator.ts
+++ b/apps/server/src/trpc/pools/creator.ts
@@ -139,6 +139,7 @@ export const poolsCreatorRouter = router({
         });
 
         let userStakeAmount = 0n;
+        let lastClaim: Date | null = null;
         if (userWallet) {
           const userStake = await prisma.stakedPool.findUnique({
             where: {
@@ -150,6 +151,7 @@ export const poolsCreatorRouter = router({
           });
 
           if (userStake) {
+            lastClaim = userStake.lastClaim;
             // For consistency, also check blockchain for updated stake amount
             if (pool.poolAddress) {
               try {
@@ -228,6 +230,7 @@ export const poolsCreatorRouter = router({
           fans: stakedPoolsCount,
           pendingRewards: userPendingRewards,
           stakedByYou: userStakeAmount,
+          lastClaim: lastClaim,
           creator: {
             userId: pool.wallet.userId!,
             address: pool.wallet.address!,

--- a/packages/constants/src/reward-pool.ts
+++ b/packages/constants/src/reward-pool.ts
@@ -15,6 +15,7 @@ export interface RewardPool {
   fans: number;
   pendingRewards: bigint;
   stakedByYou: bigint; // Amount of REVO that the requesting user has staked in this pool
+  lastClaim: Date | null;
   creator: {
     userId: number;
     address: string;
@@ -31,6 +32,7 @@ export interface SlimPoolForUserStakedPool {
   name: string;
   pendingRewards: bigint | null;
   stakedByYou: bigint;
+  lastClaim: Date | null;
 }
 
 export interface UserStakedPool {
@@ -75,6 +77,7 @@ export interface PoolDetailsForModal {
   fans: number;
   pendingRewards: bigint | null;
   stakedByYou: bigint | null; // Amount of REVO that the requesting user has staked in this pool
+  lastClaim: Date | null;
   creator: {
     userId: number;
     address: string;


### PR DESCRIPTION
- Add lastClaim timestamp field to StakedPool model in Prisma schema
- Create database index for efficient cooldown queries
- Update RewardPool interface to include lastClaim property
- Modify usePoolReader hook to calculate claim availability based on 24-hour cooldown
- Add canClaimNow and nextClaimAvailable properties to hook return
- Update StakedPoolRow component to check cooldown before allowing claims
- Display cooldown status and next available claim time in UI
- Add confirmClaim mutation to update lastClaim timestamp after successful blockchain claims
- Integrate backend confirmation with frontend claim process
- Disable claim button during cooldown period with informative tooltip
- Show 'Cooldown' status when claim is not available
- Add proper error handling and user feedback for cooldown violations