### PR TITLE
Route all blockchain reads through server proxy with Redis caching

### DIFF
--- a/apps/client/src/components/panels/explore/PoolDetailContent.tsx
+++ b/apps/client/src/components/panels/explore/PoolDetailContent.tsx
@@ -55,6 +55,7 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
     data: pool,
     isLoading,
     isError,
+    isFetching,
     refetch: refetchPoolData,
   } = useQuery({
     ...trpc.pools.fan.getPoolDetailsForModal.queryOptions({
@@ -70,16 +71,10 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
   const [isImageUploadModalOpen, setIsImageUploadModalOpen] = useState(false);
   const [isClaiming, setIsClaiming] = useState(false);
 
-  const {
-    creatorCut: contractCreatorCut,
-    fanStake: rawFanStake,
-    pendingReward,
-    isReadingPendingReward,
-    fetchAllData,
-    claimReward,
-  } = usePoolReader(
+  const { claimReward } = usePoolReader(
     pool?.address as `0x${string}` | undefined,
     userAddress as `0x${string}` | undefined,
+    pool?.chainId,
     {
       initialFanStake: pool?.stakedByYou ?? undefined,
       initialPendingReward: pool?.pendingRewards ?? undefined,
@@ -88,9 +83,6 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
 
   const chainConfig = getChainConfig(parseInt(pool?.chainId || "0"));
   const currencySymbol = chainConfig?.nativeCurrency.symbol || "REVO";
-
-  // Format the raw fan stake (bigint) to a string for display
-  const fanStake = rawFanStake ? formatEther(rawFanStake) : "0";
 
   const handleImageUploadClick = useCallback(() => {
     setIsImageUploadModalOpen(true);
@@ -179,15 +171,18 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
 
     setIsClaiming(true);
     try {
+      // Capture the claimed amount BEFORE the claim (it resets to ~0 after)
+      const claimedAmount = pool.pendingRewards ?? 0n;
+
       await claimReward(pool.id);
       // Introduce a 1-second delay to allow the blockchain to update before refetching
       await new Promise(resolve => setTimeout(resolve, 1000));
       // Refetch all pool data after successful claim
-      await fetchAllData();
+      await refetchPoolData();
 
       // Show success toast
       toast.success(
-        `Rewards claimed successfully! Your wallet has been updated with ${formatEther(pendingReward || pool.pendingRewards || BigInt(0))} ${currencySymbol}`
+        `Rewards claimed successfully! Your wallet has been updated with ${formatEther(claimedAmount)} ${currencySymbol}`
       );
     } catch (error) {
       console.error("Failed to claim rewards:", error);
@@ -361,7 +356,7 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
                         className="mt-2 px-3 py-1 bg-yellow-600 hover:bg-yellow-700 text-white rounded-lg text-xs font-medium transition-colors duration-200 disabled:opacity-50 flex items-center justify-center"
                         disabled={
                           !isWeb3Wallet ||
-                          isReadingPendingReward ||
+                          isFetching ||
                           !pool?.pendingRewards ||
                           pool.pendingRewards === BigInt(0) ||
                           isClaiming
@@ -437,8 +432,8 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
                     <div className="flex items-center justify-between">
                       <span className="text-sm font-medium text-gray-700">Take Rate:</span>
                       <span className="text-sm font-semibold text-gray-900">
-                        {contractCreatorCut !== undefined && contractCreatorCut !== null
-                          ? `${Number(contractCreatorCut) / 100}%`
+                        {pool.creatorFee !== null && pool.creatorFee !== undefined
+                          ? `${pool.creatorFee / 100}%`
                           : "N/A"}
                       </span>
                     </div>
@@ -549,13 +544,7 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
             : null
         }
         onStakeSuccess={async () => {
-          // When stake operations complete, refetch blockchain data using multicall
-          await fetchAllData();
-
-          // Refetch pool data to update fans count and other pool details
           await refetchPoolData();
-
-          // Call the original callback if provided
           onStakeSuccess?.();
         }}
       />
@@ -577,10 +566,6 @@ const PoolDetailContent: React.FC<PoolDetailContentProps> = ({
             : null
         }
         onStakeSuccess={async () => {
-          // When stake operations complete, refetch blockchain data using multicall
-          await fetchAllData();
-
-          // Refetch pool data to update fans count and other pool details
           await refetchPoolData();
 
           // Call the original callback if provided

--- a/apps/client/src/components/panels/wallet/StakedPoolRow.tsx
+++ b/apps/client/src/components/panels/wallet/StakedPoolRow.tsx
@@ -4,12 +4,12 @@ import { getChainConfig } from "@ampedbio/web3";
 import { formatUnits, formatEther } from "viem";
 import { toast } from "react-hot-toast";
 import { usePoolReader } from "../../../hooks/usePoolReader";
-import { UserStakedPoolWithNullables } from "@ampedbio/constants";
+import { UserStakedPool } from "@ampedbio/constants";
 import { useAccount } from "wagmi";
 import { useWalletContext } from "@/contexts/WalletContext";
 
 interface StakedPoolRowProps {
-  poolData: UserStakedPoolWithNullables;
+  poolData: UserStakedPool;
   refetchAllStakedPools: () => void;
   onViewPool: (poolId: number) => void;
   currentChainId: string;
@@ -21,7 +21,7 @@ export default function StakedPoolRow({
   onViewPool,
   currentChainId,
 }: StakedPoolRowProps) {
-  const { pendingRewards, stakedByYou, pool } = poolData;
+  const { pool } = poolData;
   const [isClaiming, setIsClaiming] = React.useState(false);
 
   const { address: userAddress } = useAccount();
@@ -32,14 +32,14 @@ export default function StakedPoolRow({
     claimReward,
     pendingReward: hookPendingReward,
     fanStake: hookFanStake,
-    fetchAllData,
+    refetchLiveData,
   } = usePoolReader(
     pool.address as `0x${string}` | undefined,
     userAddress as `0x${string}` | undefined,
+    currentChainId,
     { lastClaim: pool.lastClaim }
   );
 
-  const stakedAmount = stakedByYou;
   const chainConfig = getChainConfig(parseInt(currentChainId));
   const currencySymbol = chainConfig?.nativeCurrency.symbol || "REVO";
 
@@ -55,18 +55,20 @@ export default function StakedPoolRow({
       // Show a loading toast
       toast.loading("Processing claim...", { id: "claim-process" });
 
+      // Capture before claim — hookPendingReward is stale after the async write
+      const claimedAmount = hookPendingReward ?? 0n;
+
       await claimReward(pool.id);
 
       // Show success toast
       toast.success(
-        `Successfully claimed ${hookPendingReward ? parseFloat(formatEther(hookPendingReward)).toLocaleString() : "0"} ${currencySymbol}! Your wallet has been updated.`,
+        `Successfully claimed ${claimedAmount ? parseFloat(formatEther(claimedAmount)).toLocaleString() : "0"} ${currencySymbol}! Your wallet has been updated.`,
         { id: "claim-process" }
       );
 
-      // Refetch all pool data after a successful claim to update the UI
-      await fetchAllData();
-
-      // Refetch all staked pools to update the display
+      // Wait for blockchain to update, then refetch
+      await new Promise(r => setTimeout(r, 1000));
+      await refetchLiveData();
       refetchAllStakedPools();
     } catch {
       // Show error toast

--- a/apps/client/src/components/panels/wallet/StakedPoolsSection.tsx
+++ b/apps/client/src/components/panels/wallet/StakedPoolsSection.tsx
@@ -28,7 +28,7 @@ export default function StakedPoolsSection() {
 
   const totalPendingRewards =
     allStakedPools?.reduce((acc, pool) => {
-      return acc + (pool.pendingRewards ? BigInt(pool.pendingRewards) : 0n);
+      return acc + (pool.pool.pendingRewards ? BigInt(pool.pool.pendingRewards) : 0n);
     }, 0n) ?? 0n;
 
   const canClaimAll = isWeb3Wallet && totalPendingRewards > 0n && !isClaiming;

--- a/apps/client/src/components/panels/wallet/hooks/useStakedPools.ts
+++ b/apps/client/src/components/panels/wallet/hooks/useStakedPools.ts
@@ -1,10 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { trpc } from "../../../../utils/trpc";
-import { useAccount, useReadContracts, useWriteContract } from "wagmi";
+import { useAccount, useWriteContract } from "wagmi";
 import { CREATOR_POOL_ABI, getChainConfig, multicall3Abi } from "@ampedbio/web3";
-import { useMemo } from "react";
 import { type Address, encodeFunctionData } from "viem";
-import { UserStakedPoolWithNullables } from "@ampedbio/constants";
+import { UserStakedPool } from "@ampedbio/constants";
 import { toast } from "react-hot-toast";
 import { useWalletContext } from "@/contexts/WalletContext";
 
@@ -22,33 +21,7 @@ export const useStakedPools = () => {
       chainId: chainId?.toString() ?? "0",
     }),
     enabled: !!userAddress && !!chainId,
-  });
-
-  const contracts = useMemo(() => {
-    return (stakedPools || []).flatMap(pool => {
-      const poolAddress = pool.pool.address as Address;
-      return [
-        {
-          address: poolAddress,
-          abi: CREATOR_POOL_ABI,
-          functionName: "pendingReward",
-          args: [userAddress],
-        },
-        {
-          address: poolAddress,
-          abi: CREATOR_POOL_ABI,
-          functionName: "fanStakes",
-          args: [userAddress],
-        },
-      ];
-    });
-  }, [stakedPools, userAddress]);
-
-  const { data: multicallData, refetch: refetchMulticallData } = useReadContracts({
-    contracts,
-    query: {
-      enabled: (stakedPools?.length ?? 0) > 0,
-    },
+    refetchInterval: 15000,
   });
 
   const {
@@ -58,29 +31,15 @@ export const useStakedPools = () => {
     isError: isErrorClaiming,
   } = useWriteContract();
 
-  const combinedData = useMemo(() => {
-    return stakedPools?.map((pool, index) => {
-      const pendingRewards = multicallData?.[index * 2]?.result as bigint | undefined;
-      const stakedByYouResult = multicallData?.[index * 2 + 1]?.result as bigint | undefined;
-
-      return {
-        ...pool,
-        pendingRewards: pendingRewards ?? pool.pool.pendingRewards, // Use multicall data first, fallback to backend value
-        stakedByYou: stakedByYouResult ?? pool.pool.stakedByYou, // Use multicall data first, fallback to backend value
-      };
-    });
-  }, [stakedPools, multicallData]);
-
   const refetch = async () => {
     await refetchStakedPools();
-    await refetchMulticallData();
   };
 
   const claimAll = async () => {
-    if (!combinedData) return;
+    if (!stakedPools) return;
 
-    const poolsToClaim = combinedData.filter(
-      pool => pool.pendingRewards && pool.pendingRewards > 0
+    const poolsToClaim = (stakedPools ?? []).filter(
+      pool => pool.pool.pendingRewards && pool.pool.pendingRewards > 0n
     );
 
     if (poolsToClaim.length === 0) {
@@ -120,7 +79,7 @@ export const useStakedPools = () => {
   };
 
   return {
-    stakedPools: combinedData,
+    stakedPools,
     isLoading: isLoadingPools,
     refetch,
     claimAll,
@@ -128,7 +87,7 @@ export const useStakedPools = () => {
     isSuccessClaiming,
     isErrorClaiming,
   } as {
-    stakedPools: UserStakedPoolWithNullables[] | undefined;
+    stakedPools: UserStakedPool[] | undefined;
     isLoading: boolean;
     refetch: () => Promise<void>;
     claimAll: () => Promise<void>;

--- a/apps/client/src/hooks/usePoolReader.ts
+++ b/apps/client/src/hooks/usePoolReader.ts
@@ -1,8 +1,8 @@
-import { useReadContracts, useWriteContract, useReadContract, useConfig } from "wagmi";
+import { useWriteContract } from "wagmi";
 import { type Address } from "viem";
 import { CREATOR_POOL_ABI } from "@ampedbio/web3";
-import React from "react";
-import { trpcClient } from "../utils/trpc/trpc";
+import { trpcClient, trpc } from "../utils/trpc/trpc";
+import { useQuery } from "@tanstack/react-query";
 
 interface UsePoolReaderOptions {
   initialFanStake?: bigint;
@@ -11,63 +11,26 @@ interface UsePoolReaderOptions {
 }
 
 export function usePoolReader(
-  poolAddress?: Address,
-  fanAddress?: Address,
+  poolAddress: Address | undefined,
+  fanAddress: Address | undefined,
+  chainId: number | string | undefined,
   options?: UsePoolReaderOptions
 ) {
-  const poolContract = {
-    address: poolAddress,
-    abi: CREATOR_POOL_ABI,
-  } as const;
-
-  const contracts = [
-    { ...poolContract, functionName: "creatorCut" },
-    { ...poolContract, functionName: "poolName" },
-    ...(fanAddress
-      ? ([{ ...poolContract, functionName: "fanStakes", args: [fanAddress] }] as const)
-      : []),
-  ];
-
-  const { data, isLoading, refetch } = useReadContracts({
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    contracts,
-    query: {
-      enabled: !!poolAddress,
-    },
+  const hasInitialData = options?.initialFanStake !== undefined || options?.initialPendingReward !== undefined;
+  const { data: liveData, refetch: refetchLiveData } = useQuery({
+    ...trpc.pools.fan.getLiveUserPoolData.queryOptions({
+      poolAddress: poolAddress!,
+      userAddress: fanAddress!,
+      chainId: chainId?.toString() ?? "",
+    }),
+    enabled: !!poolAddress && !!fanAddress && !!chainId,
+    refetchInterval: 15000,
+    initialData: hasInitialData ? {
+      fanStakes: options?.initialFanStake?.toString() ?? "0",
+      pendingReward: options?.initialPendingReward?.toString() ?? "0",
+    } : undefined,
   });
 
-  const creatorCutResult = data?.[0];
-  const poolNameResult = data?.[1];
-  const fanStakeResult = fanAddress ? data?.[2] : undefined;
-
-  // Using useReadContract for pendingReward
-  const pendingRewardContract = useReadContract({
-    address: poolAddress,
-    abi: CREATOR_POOL_ABI,
-    functionName: "pendingReward",
-    args: fanAddress ? [fanAddress] : undefined,
-    query: {
-      enabled: !!poolAddress && !!fanAddress,
-      initialData: options?.initialPendingReward,
-    },
-  });
-
-  // Set up refetch interval to update pendingReward every 15 seconds
-  React.useEffect(() => {
-    if (!poolAddress || !fanAddress || !pendingRewardContract.refetch) return;
-
-    const interval = setInterval(() => {
-      pendingRewardContract.refetch();
-    }, 15000); // 15 seconds
-
-    return () => clearInterval(interval);
-  }, [poolAddress, fanAddress, pendingRewardContract.refetch, pendingRewardContract]);
-
-  const pendingRewardResult = pendingRewardContract.data;
-  const isPendingRewardLoading = pendingRewardContract.isLoading;
-
-  const config = useConfig();
   const { writeContractAsync: writeCreatorPoolContractAsync } = useWriteContract();
 
   const claimReward = async (poolId: number) => {
@@ -96,7 +59,6 @@ export function usePoolReader(
         console.log(`⏱️ Total claim time: ${(hashTimeMs + confirmationTimeMs).toFixed(2)}ms`);
       }
 
-      // Call backend to confirm claim and update lastClaim
       try {
         await trpcClient.pools.fan.confirmClaim.mutate({
           poolId: poolId,
@@ -104,8 +66,6 @@ export function usePoolReader(
         console.log("✅ Claim confirmed and cooldown updated");
       } catch (backendError) {
         console.error("⚠️ Failed to confirm claim with backend:", backendError);
-        // Don't throw here - the blockchain claim succeeded, which is what matters
-        // The cooldown tracking is best-effort
       }
 
       return hash;
@@ -115,34 +75,11 @@ export function usePoolReader(
     }
   };
 
-  const fetchAllData = async () => {
-    await refetch();
-    await pendingRewardContract.refetch();
-  };
-
-  // Cooldown removido - usuários podem fazer claims ilimitados
-  const canClaimNow = true;
-
-  const nextClaimAvailable = null; // Não é mais necessário
-
-  // For pendingReward, we'll use the separate query data
-  // During loading, show initial value if available, otherwise show undefined
-  const finalPendingReward = isPendingRewardLoading
-    ? options?.initialPendingReward
-    : pendingRewardResult;
-
   return {
-    creatorCut: creatorCutResult?.result as bigint | undefined,
-    isReadingCreatorCut: isLoading,
-    fanStake: isLoading
-      ? (options?.initialFanStake ?? (fanStakeResult?.result as bigint | undefined))
-      : (fanStakeResult?.result as bigint | undefined),
-    pendingReward: finalPendingReward,
-    isReadingPendingReward: isPendingRewardLoading,
-    poolName: poolNameResult?.result as string | undefined,
-    fetchAllData,
+    fanStake: liveData?.fanStakes !== undefined ? BigInt(liveData.fanStakes) : undefined,
+    pendingReward: liveData?.pendingReward !== undefined ? BigInt(liveData.pendingReward) : undefined,
+    isReadingPendingReward: false,
     claimReward,
-    canClaimNow,
-    nextClaimAvailable,
+    refetchLiveData,
   };
 }

--- a/apps/server/src/trpc/pools/creator.ts
+++ b/apps/server/src/trpc/pools/creator.ts
@@ -133,13 +133,14 @@ export const poolsCreatorRouter = router({
           where: { poolId: pool.id },
         });
 
-        // Get current user's stake in this pool (using the userId already defined at the start of this function)
+        let userStakeAmount = 0n;
+        let userPendingRewards = 0n;
+        let lastClaim: Date | null = null;
+
         const userWallet = await prisma.userWallet.findUnique({
           where: { userId },
         });
 
-        let userStakeAmount = 0n;
-        let lastClaim: Date | null = null;
         if (userWallet) {
           const userStake = await prisma.stakedPool.findUnique({
             where: {
@@ -152,63 +153,49 @@ export const poolsCreatorRouter = router({
 
           if (userStake) {
             lastClaim = userStake.lastClaim;
-            // For consistency, also check blockchain for updated stake amount
-            if (pool.poolAddress) {
-              try {
-                const chain = getChainConfig(parseInt(pool.chainId));
-                if (chain) {
-                  const publicClient = createPublicClient({
-                    chain: chain,
-                    transport: http(),
-                  });
+          }
 
-                  const fanStakeAmount = await publicClient.readContract({
+          const chain = getChainConfig(parseInt(pool.chainId));
+          if (pool.poolAddress && chain) {
+            try {
+              const publicClient = createPublicClient({
+                chain: chain,
+                transport: http(),
+              });
+
+              const [fanStakeResult, pendingRewardResult] = await publicClient.multicall({
+                contracts: [
+                  {
                     address: pool.poolAddress as Address,
                     abi: CREATOR_POOL_ABI,
                     functionName: "fanStakes",
                     args: [userWallet.address as Address],
-                  });
+                  },
+                  {
+                    address: pool.poolAddress as Address,
+                    abi: CREATOR_POOL_ABI,
+                    functionName: "pendingReward",
+                    args: [userWallet.address as Address],
+                  },
+                ],
+              });
 
-                  userStakeAmount = fanStakeAmount as bigint;
-                }
-              } catch (error) {
-                // If blockchain query fails, use the database value
-                userStakeAmount = BigInt(userStake.stakeAmount);
-                console.error(
-                  `Error fetching user stake from blockchain for pool ${pool.id}:`,
-                  error
-                );
-              }
-            } else {
-              userStakeAmount = BigInt(userStake.stakeAmount);
+              userStakeAmount = fanStakeResult.status === "success"
+                ? (fanStakeResult.result as bigint)
+                : BigInt(userStake?.stakeAmount ?? "0");
+              userPendingRewards = pendingRewardResult.status === "success"
+                ? (pendingRewardResult.result as bigint)
+                : 0n;
+            } catch (error) {
+              console.error(
+                `Error fetching data from contract for pool ${pool.id}:`,
+                error
+              );
+              userStakeAmount = BigInt(userStake?.stakeAmount ?? "0");
+              userPendingRewards = 0n;
             }
-          }
-        }
-
-        // Get user's pending rewards from the pool contract
-        let userPendingRewards = 0n;
-        const chain = getChainConfig(parseInt(pool.chainId));
-        if (userWallet && pool.poolAddress && chain) {
-          try {
-            const publicClient = createPublicClient({
-              chain: chain,
-              transport: http(),
-            });
-
-            // Use the pendingReward function to get the user's pending rewards
-            userPendingRewards = (await publicClient.readContract({
-              address: pool.poolAddress as Address,
-              abi: CREATOR_POOL_ABI,
-              functionName: "pendingReward",
-              args: [userWallet.address as Address],
-            })) as bigint;
-          } catch (error) {
-            console.error(
-              `Error fetching user pending rewards from blockchain for pool ${pool.id}:`,
-              error
-            );
-            // If blockchain query fails, return 0n as there's no fallback in the database for pending rewards
-            userPendingRewards = 0n;
+          } else if (userStake) {
+            userStakeAmount = BigInt(userStake.stakeAmount);
           }
         }
 

--- a/apps/server/src/trpc/pools/fan.ts
+++ b/apps/server/src/trpc/pools/fan.ts
@@ -17,6 +17,9 @@ import {
   getAPYCacheKey,
   getPoolsCacheKey,
   getSystemStatsCacheKey,
+  getLiveUserPoolDataCacheKey,
+  getUserStakedCacheKey,
+  getWalletStatsCacheKey,
   CACHE_TTL,
 } from "../../utils/cache";
 import {
@@ -795,6 +798,13 @@ export const poolsFanRouter = router({
     .query(async ({ ctx, input }): Promise<Array<UserStakedPool>> => {
       const userId = ctx.user!.sub;
 
+      // Check cache first
+      const userStakedCacheKey = getUserStakedCacheKey(input.chainId, userId);
+      const cachedStakedPools = await cache.get<UserStakedPool[]>(userStakedCacheKey);
+      if (cachedStakedPools !== null) {
+        return cachedStakedPools;
+      }
+
       try {
         const userWallet = await prisma.userWallet.findUnique({
           where: { userId },
@@ -1026,6 +1036,9 @@ export const poolsFanRouter = router({
         // Filter out stakes where the user has 0 stake amount
         const filteredResultStakes = resultStakes.filter(stake => stake.pool.stakedByYou > 0n);
 
+        // Cache the result
+        await cache.set(userStakedCacheKey, filteredResultStakes, CACHE_TTL.USER_STAKED);
+
         return filteredResultStakes;
       } catch (error) {
         console.error("Error getting user stakes:", error);
@@ -1212,6 +1225,14 @@ export const poolsFanRouter = router({
           console.info(
             `Stake confirmed for user ${userId} in pool ${pool.id}, amount: ${stake.amount.toString()}`
           );
+        }
+
+        // Invalidate caches after successful stake
+        try {
+          await cache.delete(getWalletStatsCacheKey(userId));
+          await cache.delete(getUserStakedCacheKey(input.chainId, userId));
+        } catch (cacheError) {
+          console.error("Failed to invalidate cache after stake:", cacheError);
         }
 
         return {
@@ -1441,6 +1462,14 @@ export const poolsFanRouter = router({
           );
         }
 
+        // Invalidate caches after successful unstake
+        try {
+          await cache.delete(getWalletStatsCacheKey(userId));
+          await cache.delete(getUserStakedCacheKey(input.chainId, userId));
+        } catch (cacheError) {
+          console.error("Failed to invalidate cache after unstake:", cacheError);
+        }
+
         return {
           success: true,
           message: `Successfully confirmed ${parsedUnstakes.length} unstake(s)`,
@@ -1596,7 +1625,7 @@ export const poolsFanRouter = router({
           // Fetch blockchain data (totalFanStaked, creatorStaked)
           (async () => {
             if (!pool.poolAddress) {
-              return { totalStake };
+              return { totalStake, creatorFee: null };
             }
 
             try {
@@ -1612,6 +1641,11 @@ export const poolsFanRouter = router({
                   abi: CREATOR_POOL_ABI,
                   functionName: "creatorStaked" as const,
                 },
+                {
+                  address: pool.poolAddress as Address,
+                  abi: CREATOR_POOL_ABI,
+                  functionName: "creatorCut" as const,
+                },
               ];
 
               // Execute all contract calls in a single batch
@@ -1622,9 +1656,11 @@ export const poolsFanRouter = router({
               // Process the results
               const totalFanStakedResult = results[0];
               const creatorStakedResult = results[1];
+              const creatorCutResult = results[2];
 
               let totalFanStaked: bigint | null = null;
               let creatorStaked: bigint | null = null;
+              let creatorFee: number | null = null;
 
               // Handle totalFanStaked result
               if (totalFanStakedResult.status === "success") {
@@ -1652,6 +1688,19 @@ export const poolsFanRouter = router({
                 );
               }
 
+              // Handle creatorCut result
+              if (creatorCutResult.status === "success") {
+                creatorFee = Number(creatorCutResult.result as bigint);
+                console.log(
+                  `Successfully fetched creatorCut from contract for pool ${pool.id}: ${creatorFee}`
+                );
+              } else {
+                console.error(
+                  `Error fetching creatorCut from contract for pool ${pool.id}:`,
+                  creatorCutResult.error
+                );
+              }
+
               // Calculate the total stake as sum of creatorStaked and totalFanStaked only if both calls succeeded
               if (totalFanStaked !== null && creatorStaked !== null) {
                 const newTotalStake = (totalFanStaked + creatorStaked) as bigint;
@@ -1673,17 +1722,17 @@ export const poolsFanRouter = router({
                   // Continue anyway, we'll still return the blockchain value
                 }
 
-                return { totalStake: newTotalStake };
+                return { totalStake: newTotalStake, creatorFee };
               } else {
                 console.warn(
                   `Could not fetch both totalFanStaked and creatorStaked for pool ${pool.id}, using DB value`
                 );
-                return { totalStake };
+                return { totalStake, creatorFee };
               }
             } catch (error) {
               console.error(`Error fetching data from contract for pool ${pool.id}:`, error);
               // If contract query fails, we'll keep the db value
-              return { totalStake };
+              return { totalStake, creatorFee: null };
             }
           })(),
 
@@ -1825,6 +1874,7 @@ export const poolsFanRouter = router({
 
         // Update values with data from blockchain calls
         totalStake = blockchainData.totalStake;
+        const creatorFee = blockchainData.creatorFee;
 
         // Fetch pool name from blockchain if not in database
         if (!poolName && pool.poolAddress && chain) {
@@ -1892,6 +1942,7 @@ export const poolsFanRouter = router({
           stakedByYou,
           lastClaim,
           apy,
+          creatorFee,
           creator: {
             userId: pool.wallet!.userId!,
             address: pool.wallet!.address!,
@@ -1906,6 +1957,65 @@ export const poolsFanRouter = router({
           message: "Failed to get pool details",
         });
       }
+    }),
+
+  getLiveUserPoolData: publicProcedure
+    .input(
+      z.object({
+        poolAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+        userAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+        chainId: z.string(),
+      })
+    )
+    .query(async ({ input }) => {
+      const cacheKey = getLiveUserPoolDataCacheKey(
+        parseInt(input.chainId),
+        input.poolAddress as Address,
+        input.userAddress as Address
+      );
+
+      const cached = await cache.get<{ fanStakes: string; pendingReward: string }>(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const chain = getChainConfig(parseInt(input.chainId));
+      if (!chain) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Unsupported chain ID" });
+      }
+
+      const publicClient = createPublicClient({ chain, transport: http() });
+      const results = await publicClient.multicall({
+        contracts: [
+          {
+            address: input.poolAddress as Address,
+            abi: CREATOR_POOL_ABI,
+            functionName: "fanStakes",
+            args: [input.userAddress as Address],
+          },
+          {
+            address: input.poolAddress as Address,
+            abi: CREATOR_POOL_ABI,
+            functionName: "pendingReward",
+            args: [input.userAddress as Address],
+          },
+        ],
+      });
+
+      const fanStakes =
+        results[0].status === "success"
+          ? (results[0].result as bigint).toString()
+          : "0";
+      const pendingReward =
+        results[1].status === "success"
+          ? (results[1].result as bigint).toString()
+          : "0";
+
+      const data = { fanStakes, pendingReward };
+
+      await cache.set(cacheKey, data, CACHE_TTL.LIVE_USER_POOL_DATA);
+
+      return data;
     }),
 
   confirmClaim: privateProcedure
@@ -1942,6 +2052,20 @@ export const poolsFanRouter = router({
             lastClaim: new Date(),
           },
         });
+
+        // Invalidate caches after successful claim
+        try {
+          const pool = await prisma.creatorPool.findUnique({
+            where: { id: input.poolId },
+            select: { chainId: true },
+          });
+          if (pool) {
+            await cache.delete(getUserStakedCacheKey(pool.chainId, userId));
+          }
+          await cache.delete(getWalletStatsCacheKey(userId));
+        } catch (cacheError) {
+          console.error("Failed to invalidate cache after claim:", cacheError);
+        }
 
         return {
           success: true,
@@ -2080,14 +2204,18 @@ export const poolsFanRouter = router({
         })) as Address[];
 
         let totalSystemStake = 0n;
-        for (const node of nodes) {
-          const delegation = (await publicClient.readContract({
+        const delegationResults = await publicClient.multicall({
+          contracts: nodes.map(node => ({
             address: chain.contracts.NODE_MANAGER.address,
             abi: NODE_MANAGER_ABI,
             functionName: "nodeTotalDelegation",
             args: [node as Address],
-          })) as bigint;
-          totalSystemStake += delegation;
+          })),
+        });
+        for (const result of delegationResults) {
+          if (result.status === "success") {
+            totalSystemStake += result.result as bigint;
+          }
         }
 
         const result = {

--- a/apps/server/src/trpc/referral.ts
+++ b/apps/server/src/trpc/referral.ts
@@ -12,7 +12,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { createWalletClient, createPublicClient, http } from "viem";
 import { getChainConfig } from "@ampedbio/web3";
 import { AFFILIATES_CHAIN_ID, SITE_SETTINGS, PROCESSING_TXID } from "@ampedbio/constants";
-import { cache, CacheKeys } from "../utils/cache";
+import { cache, CacheKeys, CACHE_TTL, getAffiliateBalanceCacheKey } from "../utils/cache";
 
 // Helper function to check affiliate wallet balance
 async function getAffiliateWalletStatus() {
@@ -72,12 +72,33 @@ async function getAffiliateWalletStatus() {
 
     const requiredAmount = (referrerReward || 0) + (refereeReward || 0);
 
+    // Check balance cache first
+    const balanceCacheKey = getAffiliateBalanceCacheKey(AFFILIATES_CHAIN_ID);
+    const cachedBalance = await cache.get<{ balance: string; hasBalance: boolean }>(balanceCacheKey);
+
+    if (cachedBalance !== null) {
+      return {
+        hasBalance: cachedBalance.hasBalance,
+        balance: cachedBalance.balance,
+        requiredAmount,
+        currency: chain.nativeCurrency.symbol,
+      };
+    }
+
+    // Cache miss — fetch from RPC
     const balance = await publicClient.getBalance({ address: account.address });
     const balanceInEther = Number(balance) / 1e18;
 
-    return {
-      hasBalance: balanceInEther >= requiredAmount,
+    const result = {
       balance: balanceInEther.toFixed(4),
+      hasBalance: balanceInEther >= requiredAmount,
+    };
+
+    await cache.set(balanceCacheKey, result, CACHE_TTL.AFFILIATE_BALANCE);
+
+    return {
+      hasBalance: result.hasBalance,
+      balance: result.balance,
       requiredAmount,
       currency: chain.nativeCurrency.symbol,
     };
@@ -613,6 +634,13 @@ export const referralRouter = router({
           `[REFERRAL_CLAIM_SUCCESS] userId=${userId}, referralId=${input.referralId}, txid=${result.txid}`
         );
 
+        // Invalidate affiliate balance cache after successful claim
+        try {
+          await cache.delete(getAffiliateBalanceCacheKey(AFFILIATES_CHAIN_ID));
+        } catch (cacheError) {
+          console.error("Failed to invalidate affiliate balance cache:", cacheError);
+        }
+
         return result;
       } catch (error) {
         if (error instanceof TRPCError) {
@@ -940,6 +968,13 @@ export const referralRouter = router({
         console.log(
           `[REFEREE_CLAIM_SUCCESS] userId=${userId}, referralId=${input.referralId}, txid=${result.txid}`
         );
+
+        // Invalidate affiliate balance cache after successful claim
+        try {
+          await cache.delete(getAffiliateBalanceCacheKey(AFFILIATES_CHAIN_ID));
+        } catch (cacheError) {
+          console.error("Failed to invalidate affiliate balance cache:", cacheError);
+        }
 
         return result;
       } catch (error) {

--- a/apps/server/src/trpc/wallet.ts
+++ b/apps/server/src/trpc/wallet.ts
@@ -10,7 +10,7 @@ import { getChainConfig } from "@ampedbio/web3";
 import * as jose from "jose";
 import Decimal from "decimal.js";
 import { SITE_SETTINGS } from "@ampedbio/constants";
-import { cache, CACHE_TTL, getMethodSignatureCacheKey } from "../utils/cache";
+import { cache, CACHE_TTL, getMethodSignatureCacheKey, getFaucetBalanceCacheKey, getWalletStatsCacheKey } from "../utils/cache";
 
 // Schema for requesting faucet tokens
 const faucetRequestSchema = z.object({
@@ -241,7 +241,7 @@ export const walletRouter = router({
         const faucetAmount = Number(env.FAUCET_AMOUNT);
         let hasSufficientFunds = true; // Assume true by default
 
-        // If not in mock mode, check the actual balance of the faucet
+        // If not in mock mode, check the actual balance of the faucet (with cache)
         if (env.FAUCET_MOCK_MODE !== "true") {
           if (!env.FAUCET_PRIVATE_KEY) {
             throw new TRPCError({
@@ -250,21 +250,30 @@ export const walletRouter = router({
             });
           }
 
-          const publicClient = createPublicClient({
-            chain,
-            transport: http(chain.rpcUrls.default.http[0]),
-          });
+          const balanceCacheKey = getFaucetBalanceCacheKey(input.chainId);
+          const cachedBalance = await cache.get<{ hasSufficientFunds: boolean }>(balanceCacheKey);
 
-          const account = privateKeyToAccount(env.FAUCET_PRIVATE_KEY as `0x${string}`);
-          const balance = await publicClient.getBalance({ address: account.address });
-          // Use Decimal for precise conversion from wei to ether
-          const balanceInEther = new Decimal(balance.toString())
-            .div(new Decimal("10").pow(18))
-            .toNumber();
+          if (cachedBalance !== null) {
+            hasSufficientFunds = cachedBalance.hasSufficientFunds;
+          } else {
+            const publicClient = createPublicClient({
+              chain,
+              transport: http(chain.rpcUrls.default.http[0]),
+            });
 
-          // Check if the faucet has enough balance for the airdrop
-          if (balanceInEther < faucetAmount) {
-            hasSufficientFunds = false;
+            const account = privateKeyToAccount(env.FAUCET_PRIVATE_KEY as `0x${string}`);
+            const balance = await publicClient.getBalance({ address: account.address });
+            // Use Decimal for precise conversion from wei to ether
+            const balanceInEther = new Decimal(balance.toString())
+              .div(new Decimal("10").pow(18))
+              .toNumber();
+
+            // Check if the faucet has enough balance for the airdrop
+            if (balanceInEther < faucetAmount) {
+              hasSufficientFunds = false;
+            }
+
+            await cache.set(balanceCacheKey, { hasSufficientFunds }, CACHE_TTL.FAUCET_BALANCE);
           }
         }
 
@@ -528,6 +537,13 @@ export const walletRouter = router({
 
           console.log(`${isMockMode ? "[MOCK] " : ""}Transaction sent: ${hash}`);
 
+          // Invalidate faucet balance cache after airdrop
+          try {
+            await cache.delete(getFaucetBalanceCacheKey(input.chainId));
+          } catch (cacheError) {
+            console.error("Failed to invalidate faucet balance cache:", cacheError);
+          }
+
           // Create a transaction record
           const transaction = {
             id: hash, // Use the hash as the ID
@@ -704,6 +720,24 @@ export const walletRouter = router({
     const userId = ctx.user!.sub;
 
     try {
+      // Check cache first
+      const cacheKey = getWalletStatsCacheKey(userId);
+      const cached = await cache.get<{
+        myStake: string;
+        stakedToMe: string;
+        stakersSupportingMe: number;
+        creatorPoolsJoined: number;
+      }>(cacheKey);
+
+      if (cached !== null) {
+        return {
+          myStake: BigInt(cached.myStake),
+          stakedToMe: BigInt(cached.stakedToMe),
+          stakersSupportingMe: cached.stakersSupportingMe,
+          creatorPoolsJoined: cached.creatorPoolsJoined,
+        };
+      }
+
       // Get user's wallet
       const userWallet = await prisma.userWallet.findUnique({
         where: { userId },
@@ -792,6 +826,15 @@ export const walletRouter = router({
           },
         },
       });
+
+      // Cache the result
+      const statsData = {
+        myStake: myStake.toString(),
+        stakedToMe: stakedToMe.toString(),
+        stakersSupportingMe,
+        creatorPoolsJoined,
+      };
+      await cache.set(cacheKey, statsData, CACHE_TTL.WALLET_STATS);
 
       return {
         myStake: myStake, // Return as bigint (wei)

--- a/apps/server/src/utils/cache.ts
+++ b/apps/server/src/utils/cache.ts
@@ -117,6 +117,27 @@ export const CACHE_TTL = {
    * Function signatures rarely change once deployed.
    */
   METHOD_SIGNATURE: 604800,
+  /**
+   * 10 seconds - Live per-user per-pool on-chain data (fanStakes, pendingReward).
+   * Short TTL to keep data fresh while absorbing 15s client polling.
+   */
+  LIVE_USER_POOL_DATA: 10,
+  /**
+   * 10 seconds - User staked pools list (polling absorption).
+   */
+  USER_STAKED: 10,
+  /**
+   * 30 seconds - Faucet wallet balance.
+   */
+  FAUCET_BALANCE: 30,
+  /**
+   * 60 seconds - Affiliate wallet balance.
+   */
+  AFFILIATE_BALANCE: 60,
+  /**
+   * 30 seconds - Wallet stats (myStake, stakedToMe, etc.).
+   */
+  WALLET_STATS: 30,
 } as const;
 
 /**
@@ -150,6 +171,31 @@ export enum CacheKeys {
    * Format: `system_stats:${chainId}`
    */
   SYSTEM_STATS_PREFIX = "system_stats",
+  /**
+   * Cache key prefix for live per-user per-pool on-chain data (fanStakes, pendingReward).
+   * Format: `live_user_pool:${chainId}:${poolAddress}:${userAddress}`
+   */
+  LIVE_USER_POOL_DATA_PREFIX = "live_user_pool",
+  /**
+   * Cache key prefix for user staked pools (polling absorption).
+   * Format: `user_staked:${chainId}:${userId}`
+   */
+  USER_STAKED_PREFIX = "user_staked",
+  /**
+   * Cache key prefix for faucet wallet balance.
+   * Format: `faucet_balance:${chainId}`
+   */
+  FAUCET_BALANCE_PREFIX = "faucet_balance",
+  /**
+   * Cache key prefix for affiliate wallet balance.
+   * Format: `affiliate_balance:${chainId}`
+   */
+  AFFILIATE_BALANCE_PREFIX = "affiliate_balance",
+  /**
+   * Cache key prefix for wallet stats.
+   * Format: `wallet_stats:${userId}`
+   */
+  WALLET_STATS_PREFIX = "wallet_stats",
 }
 
 /**
@@ -294,4 +340,28 @@ export function getMethodSignatureCacheKey(selector: string): string {
 
 export function getSystemStatsCacheKey(chainId: number): string {
   return `${CacheKeys.SYSTEM_STATS_PREFIX}:${chainId}`;
+}
+
+export function getLiveUserPoolDataCacheKey(
+  chainId: number,
+  poolAddress: Address,
+  userAddress: Address
+): string {
+  return `${CacheKeys.LIVE_USER_POOL_DATA_PREFIX}:${chainId}:${poolAddress}:${userAddress}`;
+}
+
+export function getUserStakedCacheKey(chainId: string, userId: string | number): string {
+  return `${CacheKeys.USER_STAKED_PREFIX}:${chainId}:${userId}`;
+}
+
+export function getFaucetBalanceCacheKey(chainId: number): string {
+  return `${CacheKeys.FAUCET_BALANCE_PREFIX}:${chainId}`;
+}
+
+export function getAffiliateBalanceCacheKey(chainId: number): string {
+  return `${CacheKeys.AFFILIATE_BALANCE_PREFIX}:${chainId}`;
+}
+
+export function getWalletStatsCacheKey(userId: string | number): string {
+  return `${CacheKeys.WALLET_STATS_PREFIX}:${userId}`;
 }

--- a/packages/constants/src/reward-pool.ts
+++ b/packages/constants/src/reward-pool.ts
@@ -90,6 +90,7 @@ export interface PoolDetailsForModal {
   stakedByYou: bigint | null; // Amount of REVO that the requesting user has staked in this pool
   lastClaim: Date | null;
   apy?: number; // APY in basis points (e.g., 1250 = 12.5%)
+  creatorFee: number | null; // Creator fee in basis points (e.g., 2500 = 25%)
   creator: {
     userId: number;
     address: string;


### PR DESCRIPTION

## Summary

Eliminates browser-origin RPC calls by proxying all on-chain reads through tRPC endpoints backed by server-side multicalls and Redis caching. Replaces wagmi `useReadContract`/`useReadContracts` with cached tRPC queries that absorb 15s client polling, reducing per-session RPC calls by ~30-80.

## Changes

### Server
- **New endpoint** `getLiveUserPoolData` — per-user per-pool fanStakes + pendingReward via multicall + 10s Redis cache
- **`getPoolDetailsForModal`** now returns `creatorFee` (fetched via multicall alongside totalStake)
- **`getPool` (creator)** unified two sequential `readContract` calls into one multicall
- **`getSystemStats`** replaced N sequential `readContract` loop with single multicall
- **Redis caching** added to `getUserStakedPools`, `getFaucetAmount`, `getWalletStats`, `getAffiliateWalletStatus`
- **Cache invalidation** on `confirmStake`, `confirmUnstake`, `confirmClaim`, `requestAirdrop`, `claimReferralReward`, `claimRefereeReward`

### Client
- **`usePoolReader`** rewritten — wagmi hooks replaced with tRPC `useQuery` polling through server
- **`useStakedPools`** removed redundant `useReadContracts` + `combinedData`; server data used directly
- **`PoolDetailContent`** uses `pool.creatorFee` instead of browser-fetched `contractCreatorCut`
- **`StakedPoolRow`** passes `chainId` to `usePoolReader`, captures claimed amount before async write
- **`StakedPoolsSection`** updated to use nested `pool.pool.pendingRewards` access path

### Shared
- Added `creatorFee` field to `PoolDetailsForModal` interface
- Added 5 new cache key prefixes, TTLs, and helper functions to `cache.ts`

## Architecture

```
BEFORE: Browser → RPC (direct reads via wagmi)
AFTER:  Browser → tRPC → Server → Redis/RPC (cached proxy)
```

💘 Generated with Crush