### PR TITLE
Gate faucet access behind profile completion requirements

### DIFF
--- a/apps/client/src/components/panels/wallet/dialogs/FaucetRequirementsChecklist.tsx
+++ b/apps/client/src/components/panels/wallet/dialogs/FaucetRequirementsChecklist.tsx
@@ -1,0 +1,118 @@
+import { Check, ArrowRight } from "lucide-react";
+
+interface Requirement {
+  key: string;
+  label: string;
+  description: string;
+  completed: boolean;
+  actionHref: string;
+  actionLabel: string;
+}
+
+interface FaucetRequirementsChecklistProps {
+  requirements: Record<string, boolean>;
+}
+
+const STEPS: Omit<Requirement, "completed">[] = [
+  {
+    key: "photo",
+    label: "Profile Photo",
+    description: "Upload a profile picture",
+    actionHref: "/editor?tab=profile",
+    actionLabel: "Upload Photo",
+  },
+  {
+    key: "background",
+    label: "Background Image",
+    description: "Set a background for your page",
+    actionHref: "/editor?tab=theme",
+    actionLabel: "Set Background",
+  },
+  {
+    key: "bio",
+    label: "Bio / About Text",
+    description: "Write a short bio about yourself",
+    actionHref: "/editor?tab=profile",
+    actionLabel: "Write Bio",
+  },
+  {
+    key: "minLinks",
+    label: "At Least 5 Links",
+    description: "Add 5 or more links to your page",
+    actionHref: "/editor?tab=links",
+    actionLabel: "Add Links",
+  },
+];
+
+export function FaucetRequirementsChecklist({ requirements }: FaucetRequirementsChecklistProps) {
+  const steps: Requirement[] = STEPS.map(step => ({
+    ...step,
+    completed: requirements[step.key] ?? false,
+  }));
+
+  const completedCount = steps.filter(s => s.completed).length;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-700">Profile Completion</h4>
+        <span className="text-xs font-medium text-gray-500">
+          {completedCount}/{steps.length}
+        </span>
+      </div>
+
+      <div className="w-full h-1.5 bg-gray-200 rounded-full mb-3">
+        <div
+          className="h-full bg-green-500 rounded-full transition-all duration-500"
+          style={{ width: `${(completedCount / steps.length) * 100}%` }}
+        />
+      </div>
+
+      <div className="space-y-2">
+        {steps.map(step => (
+          <div
+            key={step.key}
+            className={`flex items-center justify-between p-2 rounded-lg transition-colors ${
+              step.completed ? "bg-green-50" : "bg-white border border-gray-100"
+            }`}
+          >
+            <div className="flex items-center space-x-3">
+              {step.completed ? (
+                <div className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center flex-shrink-0">
+                  <Check className="w-3 h-3 text-white" />
+                </div>
+              ) : (
+                <div className="w-5 h-5 rounded-full border-2 border-gray-300 flex items-center justify-center flex-shrink-0" />
+              )}
+              <div>
+                <p
+                  className={`text-sm font-medium ${
+                    step.completed ? "text-green-800" : "text-gray-700"
+                  }`}
+                >
+                  {step.label}
+                </p>
+                <p className="text-xs text-gray-500">{step.description}</p>
+              </div>
+            </div>
+            {!step.completed && (
+              <a
+                href={step.actionHref}
+                className="flex items-center space-x-1 text-xs font-medium text-blue-600 hover:text-blue-700 transition-colors flex-shrink-0 ml-2"
+              >
+                <span>{step.actionLabel}</span>
+                <ArrowRight className="w-3 h-3" />
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {completedCount < steps.length && (
+        <p className="text-xs text-gray-500 mt-3 text-center">
+          Complete all steps above to unlock the faucet
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/components/panels/wallet/dialogs/FaucetRequirementsChecklist.tsx
+++ b/apps/client/src/components/panels/wallet/dialogs/FaucetRequirementsChecklist.tsx
@@ -1,7 +1,14 @@
 import { Check, ArrowRight } from "lucide-react";
 
+type FaucetRequirements = {
+  photo: boolean;
+  background: boolean;
+  bio: boolean;
+  minLinks: boolean;
+};
+
 interface Requirement {
-  key: string;
+  key: keyof FaucetRequirements;
   label: string;
   description: string;
   completed: boolean;
@@ -10,7 +17,7 @@ interface Requirement {
 }
 
 interface FaucetRequirementsChecklistProps {
-  requirements: Record<string, boolean>;
+  requirements: FaucetRequirements;
 }
 
 const STEPS: Omit<Requirement, "completed">[] = [

--- a/apps/client/src/components/panels/wallet/dialogs/FundWalletDialog.tsx
+++ b/apps/client/src/components/panels/wallet/dialogs/FundWalletDialog.tsx
@@ -5,6 +5,7 @@ import OnRampIcon from "@/assets/icons/onramp.png";
 import { useState, useEffect } from "react";
 import { useFundWalletDialog } from "../hooks/useFundWalletDialog";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { FaucetRequirementsChecklist } from "./FaucetRequirementsChecklist";
 
 // Component to display countdown timer
 function CountdownTimer({ targetDate, onComplete }: { targetDate: Date; onComplete?: () => void }) {
@@ -86,6 +87,12 @@ function FundWalletDialog({ open, onOpenChange, openReceiveModal }: FundWalletDi
   });
 
   const [rewardClaimed, setRewardClaimed] = useState(!faucetInfo.canRequestNow);
+
+  const allRequirementsMet =
+    faucetInfo.requirements.photo &&
+    faucetInfo.requirements.background &&
+    faucetInfo.requirements.bio &&
+    faucetInfo.requirements.minLinks;
 
   useEffect(() => {
     setRewardClaimed(!faucetInfo.canRequestNow);
@@ -195,7 +202,8 @@ function FundWalletDialog({ open, onOpenChange, openReceiveModal }: FundWalletDi
                       !faucetInfo.faucetEnabled ||
                       claimingFaucet ||
                       !faucetInfo.canRequestNow ||
-                      !faucetInfo.hasSufficientFunds
+                      !faucetInfo.hasSufficientFunds ||
+                      !allRequirementsMet
                     }
                     className={`px-4 py-2 rounded-lg font-medium transition-all duration-300 flex items-center space-x-2 ${
                       !faucetInfo.faucetEnabled
@@ -236,6 +244,11 @@ function FundWalletDialog({ open, onOpenChange, openReceiveModal }: FundWalletDi
                   </button>
                 </div>
               </div>
+
+              {/* Requirements Checklist */}
+              {!isLoadingFaucetAmount && faucetInfo.faucetEnabled && (
+                <FaucetRequirementsChecklist requirements={faucetInfo.requirements} />
+              )}
 
               {/* Bridge */}
               <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 hover:shadow-md transition-shadow duration-200">

--- a/apps/client/src/components/panels/wallet/dialogs/FundWalletDialog.tsx
+++ b/apps/client/src/components/panels/wallet/dialogs/FundWalletDialog.tsx
@@ -210,7 +210,7 @@ function FundWalletDialog({ open, onOpenChange, openReceiveModal }: FundWalletDi
                         ? "bg-gray-400 text-white cursor-not-allowed"
                         : !faucetInfo.canRequestNow
                           ? "bg-blue-600 text-white cursor-default"
-                          : claimingFaucet || !faucetInfo.hasSufficientFunds
+                          : claimingFaucet || !faucetInfo.hasSufficientFunds || !allRequirementsMet
                             ? "bg-gray-400 text-white cursor-not-allowed"
                             : "bg-green-600 hover:bg-green-700 text-white hover:scale-105"
                     }`}
@@ -234,6 +234,11 @@ function FundWalletDialog({ open, onOpenChange, openReceiveModal }: FundWalletDi
                       <>
                         <Gift className="w-4 h-4" />
                         <span>Out of Funds</span>
+                      </>
+                    ) : !allRequirementsMet ? (
+                      <>
+                        <Gift className="w-4 h-4" />
+                        <span>Complete Profile</span>
                       </>
                     ) : (
                       <>

--- a/apps/client/src/components/panels/wallet/hooks/useFundWalletDialog.ts
+++ b/apps/client/src/components/panels/wallet/hooks/useFundWalletDialog.ts
@@ -28,15 +28,22 @@ export function useFundWalletDialog(params: {
     nextAvailableDate: Date | null;
     canRequestNow: boolean;
     hasWallet: boolean;
-    hasSufficientFunds: boolean; // New state for faucet balance
+    hasSufficientFunds: boolean;
     faucetEnabled: boolean;
+    requirements: {
+      photo: boolean;
+      background: boolean;
+      bio: boolean;
+      minLinks: boolean;
+    };
   }>({
     lastRequestDate: null,
     nextAvailableDate: null,
     canRequestNow: true,
     hasWallet: false,
-    hasSufficientFunds: true, // Default to true
+    hasSufficientFunds: true,
     faucetEnabled: false,
+    requirements: { photo: false, background: false, bio: false, minLinks: false },
   });
 
   // Fetch faucet amount and status when the dialog is opened
@@ -57,8 +64,9 @@ export function useFundWalletDialog(params: {
           nextAvailableDate: result.nextAvailableDate ? new Date(result.nextAvailableDate) : null,
           canRequestNow: result.canRequestNow,
           hasWallet: result.hasWallet,
-          hasSufficientFunds: result.hasSufficientFunds, // Update based on API response
-          faucetEnabled: result.faucetEnabled, // Set global faucet status
+          hasSufficientFunds: result.hasSufficientFunds,
+          faucetEnabled: result.faucetEnabled,
+          requirements: result.requirements ?? { photo: false, background: false, bio: false, minLinks: false },
         });
       } catch (error: any) {
         console.error("Failed to fetch faucet amount or status:", error);
@@ -93,6 +101,13 @@ export function useFundWalletDialog(params: {
     // Prevent claim if faucet has insufficient funds
     if (!faucetInfo.hasSufficientFunds) {
       toast.error("The faucet is currently out of funds. Please try again later.");
+      return { success: false };
+    }
+
+    // Prevent claim if profile requirements are not met
+    const reqs = faucetInfo.requirements;
+    if (!reqs.photo || !reqs.background || !reqs.bio || !reqs.minLinks) {
+      toast.error("Complete your profile to unlock the faucet.");
       return { success: false };
     }
 

--- a/apps/server/src/trpc/wallet.ts
+++ b/apps/server/src/trpc/wallet.ts
@@ -12,6 +12,45 @@ import Decimal from "decimal.js";
 import { SITE_SETTINGS } from "@ampedbio/constants";
 import { cache, CACHE_TTL, getMethodSignatureCacheKey } from "../utils/cache";
 
+async function getFaucetRequirements(userId: number) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      image: true,
+      image_file_id: true,
+      description: true,
+      theme: true,
+    },
+  });
+
+  if (!user) {
+    return { photo: false, background: false, bio: false, minLinks: false };
+  }
+
+  const hasPhoto = !!(user.image || user.image_file_id);
+
+  let hasBackground = false;
+  if (user.theme) {
+    const themeRecord = await prisma.theme.findUnique({
+      where: { id: Number(user.theme) },
+      select: { config: true },
+    });
+    if (themeRecord?.config) {
+      const config = themeRecord.config as { background?: { type: string; value: string | null } };
+      hasBackground = config.background?.type === "image" && !!config.background?.value;
+    }
+  }
+
+  const hasBio = !!(user.description && user.description.trim().length > 0);
+
+  const linkBlockCount = await prisma.block.count({
+    where: { user_id: userId, type: "link" },
+  });
+  const hasMinLinks = linkBlockCount >= 5;
+
+  return { photo: hasPhoto, background: hasBackground, bio: hasBio, minLinks: hasMinLinks };
+}
+
 // Schema for requesting faucet tokens
 const faucetRequestSchema = z.object({
   publicKey: z.string(),
@@ -233,7 +272,13 @@ export const walletRouter = router({
             canRequestNow: false,
             hasWallet: false,
             hasSufficientFunds: false,
-            faucetEnabled: false, // Indicate that the faucet is disabled
+            faucetEnabled: false,
+            requirements: {
+              photo: false,
+              background: false,
+              bio: false,
+              minLinks: false,
+            },
           };
         }
 
@@ -300,8 +345,9 @@ export const walletRouter = router({
           nextAvailableDate,
           canRequestNow,
           hasWallet: !!userWallet,
-          hasSufficientFunds, // Return the flag to the client
-          faucetEnabled, // Return the faucet enabled status
+          hasSufficientFunds,
+          faucetEnabled,
+          requirements: await getFaucetRequirements(userId),
         };
       } catch (error) {
         console.error("Error getting faucet amount:", error);
@@ -312,6 +358,11 @@ export const walletRouter = router({
         });
       }
     }),
+
+  checkFaucetRequirements: privateProcedure.query(async ({ ctx }) => {
+    const userId = ctx.user!.sub;
+    return getFaucetRequirements(userId);
+  }),
 
   // Get the wallet address linked to the current user (1:1 relationship)
   getUserWallet: privateProcedure.query(async ({ ctx }) => {
@@ -481,6 +532,33 @@ export const walletRouter = router({
               last_airdrop_request: now,
               updated_at: now,
             },
+          });
+        }
+
+        // Validate faucet profile requirements
+        const requirements = await getFaucetRequirements(userId);
+        if (!requirements.photo) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a profile photo to claim faucet tokens.",
+          });
+        }
+        if (!requirements.background) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a background image to claim faucet tokens.",
+          });
+        }
+        if (!requirements.bio) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a bio to claim faucet tokens.",
+          });
+        }
+        if (!requirements.minLinks) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need at least 5 links to claim faucet tokens.",
           });
         }
 

--- a/apps/server/src/trpc/wallet.ts
+++ b/apps/server/src/trpc/wallet.ts
@@ -12,16 +12,30 @@ import Decimal from "decimal.js";
 import { SITE_SETTINGS } from "@ampedbio/constants";
 import { cache, CACHE_TTL, getMethodSignatureCacheKey } from "../utils/cache";
 
+const themeConfigSchema = z.object({
+  background: z
+    .object({
+      type: z.string(),
+      value: z.string().nullable(),
+    })
+    .optional(),
+});
+
 async function getFaucetRequirements(userId: number) {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      image: true,
-      image_file_id: true,
-      description: true,
-      theme: true,
-    },
-  });
+  const [user, linkBlockCount] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        image: true,
+        image_file_id: true,
+        description: true,
+        theme: true,
+      },
+    }),
+    prisma.block.count({
+      where: { user_id: userId, type: "link" },
+    }),
+  ]);
 
   if (!user) {
     return { photo: false, background: false, bio: false, minLinks: false };
@@ -36,16 +50,15 @@ async function getFaucetRequirements(userId: number) {
       select: { config: true },
     });
     if (themeRecord?.config) {
-      const config = themeRecord.config as { background?: { type: string; value: string | null } };
-      hasBackground = config.background?.type === "image" && !!config.background?.value;
+      const parsed = themeConfigSchema.safeParse(themeRecord.config);
+      if (parsed.success) {
+        hasBackground =
+          parsed.data.background?.type === "image" && !!parsed.data.background?.value;
+      }
     }
   }
 
   const hasBio = !!(user.description && user.description.trim().length > 0);
-
-  const linkBlockCount = await prisma.block.count({
-    where: { user_id: userId, type: "link" },
-  });
   const hasMinLinks = linkBlockCount >= 5;
 
   return { photo: hasPhoto, background: hasBackground, bio: hasBio, minLinks: hasMinLinks };
@@ -361,7 +374,15 @@ export const walletRouter = router({
 
   checkFaucetRequirements: privateProcedure.query(async ({ ctx }) => {
     const userId = ctx.user!.sub;
-    return getFaucetRequirements(userId);
+    try {
+      return await getFaucetRequirements(userId);
+    } catch (error) {
+      console.error("Error checking faucet requirements:", error);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to check faucet requirements",
+      });
+    }
   }),
 
   // Get the wallet address linked to the current user (1:1 relationship)
@@ -468,6 +489,33 @@ export const walletRouter = router({
 
         const now = new Date();
 
+        // Validate faucet profile requirements
+        const requirements = await getFaucetRequirements(userId);
+        if (!requirements.photo) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a profile photo to claim faucet tokens.",
+          });
+        }
+        if (!requirements.background) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a background image to claim faucet tokens.",
+          });
+        }
+        if (!requirements.bio) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need a bio to claim faucet tokens.",
+          });
+        }
+        if (!requirements.minLinks) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "You need at least 5 links to claim faucet tokens.",
+          });
+        }
+
         // Find user's wallet (1:1 relationship - each user can have only one wallet)
         let wallet = await prisma.userWallet.findFirst({
           where: { userId: userId },
@@ -532,33 +580,6 @@ export const walletRouter = router({
               last_airdrop_request: now,
               updated_at: now,
             },
-          });
-        }
-
-        // Validate faucet profile requirements
-        const requirements = await getFaucetRequirements(userId);
-        if (!requirements.photo) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message: "You need a profile photo to claim faucet tokens.",
-          });
-        }
-        if (!requirements.background) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message: "You need a background image to claim faucet tokens.",
-          });
-        }
-        if (!requirements.bio) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message: "You need a bio to claim faucet tokens.",
-          });
-        }
-        if (!requirements.minLinks) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message: "You need at least 5 links to claim faucet tokens.",
           });
         }
 


### PR DESCRIPTION

## Summary

Requires users to complete their profile before claiming faucet tokens: profile photo, background image, bio text, and at least 5 links. Displays completion progress as a visual checklist in the faucet dialog.

## Changes

### Server (`apps/server/src/trpc/wallet.ts`)
- **New endpoint** `checkFaucetRequirements` — returns `{ photo, background, bio, minLinks }` booleans
- **`getFaucetAmount`** extended with `requirements` field in response
- **`requestAirdrop`** validates all 4 requirements server-side before sending transaction

### Client
- **`FaucetRequirementsChecklist`** (new component) — progress bar, 4 steps with check icons, action links to editor tabs
- **`useFundWalletDialog`** — requirements state added, frontend validation before claim
- **`FundWalletDialog`** — checklist rendered between faucet bar and Bridge section, claim button gated on all requirements

### How it works
```
Faucet dialog opens → getFaucetAmount returns requirements → checklist shows 0/4
→ User completes steps via editor → dialog reopens → 4/4 unlocks claim button
→ requestAirdrop re-validates server-side
```

💘 Generated with Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profile completion checklist to the wallet funding dialog.
  * Added progress tracking for profile photo, background, bio, and linked blocks.
  * Added direct actions to complete missing profile requirements.

* **Bug Fixes**
  * Faucet claims are now blocked until all profile requirements are completed.
  * Added clear messages explaining which requirement is missing.
  * Improved validation to prevent ineligible faucet requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->